### PR TITLE
Removed typo space between 2 and > in wrapInScript.sh

### DIFF
--- a/resources/analysisTools/roddyTools/wrapInScript.sh
+++ b/resources/analysisTools/roddyTools/wrapInScript.sh
@@ -320,7 +320,7 @@ else
   export WRAPPED_SCRIPT=${WRAPPED_SCRIPT} # Export script so it can identify itself
 
   # Create directories
-  mkdir -p ${DIR_TEMP} 2 > /dev/null
+  mkdir -p ${DIR_TEMP} 2> /dev/null
 
   echo "Calling script ${WRAPPED_SCRIPT}"
   jobProfilerBinary=${JOB_PROFILER_BINARY-}


### PR DESCRIPTION
Let's hope this is the source of the "dreadful 2" directory :-P