### PR TITLE
Remove autocheckpoint code. Improve debugging.

### DIFF
--- a/resources/analysisTools/roddyTools/wrapInScript.sh
+++ b/resources/analysisTools/roddyTools/wrapInScript.sh
@@ -330,13 +330,11 @@ else
   outputFileGroup=${outputFileGroup-$myGroup}
 
   exitCode=0
+  [[ ${disableDebugOptionsForToolscript-false} == true ]] && export WRAPPED_SCRIPT_DEBUG_OPTIONS=""
   echo "######################################################### Starting wrapped script ###########################################################"
-  $jobProfilerBinary bash -x ${WRAPPED_SCRIPT} 1>> /dev/stdout 2>> /dev/stderr || exitCode=$?
+  $jobProfilerBinary bash ${WRAPPED_SCRIPT_DEBUG_OPTIONS-} ${WRAPPED_SCRIPT} || exitCode=$?
   echo "######################################################### Wrapped script ended ##############################################################"
   echo "Exited script ${WRAPPED_SCRIPT} with value ${exitCode}"
-
-  # If the tool supports auto checkpoints and the exit code is 0, then go on and create it.
-  [[ ${AUTOCHECKPOINT-""} && exitCode == 0 ]] && touch ${AUTOCHECKPOINT}
 
   sleep 2
 


### PR DESCRIPTION
Wrapper contained auto checkpoint code which was never used. Removed
this.

Wrapper will deactivate script debugging if
disableDebugOptionsForToolscript is set to true!

The WRAPPED_SCRIPT_DEBUG_OPTIONS variable is now used to set debugging
features for the wrapped script.